### PR TITLE
Fix 'float' object has no attribute 'sqrt' error when aperture radius is used in sag computation

### DIFF
--- a/deeplens/geolens.py
+++ b/deeplens/geolens.py
@@ -2357,7 +2357,10 @@ class GeoLens(Lens):
             d_aper = 0.1 if self.is_cellphone else 2.0
 
             # If the first surface is concave, use the maximum negative sag.
-            aper_r = self.surfaces[aper_idx].r
+            # Convert float to tensor to avoid error
+            aper_r = torch.tensor(self.surfaces[aper_idx].r, device=self.device)
+            y = torch.tensor(0.0, device=self.device)
+
             # sag1 = -self.surfaces[aper_idx + 1].surface(aper_r, 0).item()
             sag1 = -self.surfaces[aper_idx + 1].sag(aper_r, 0).item()
             if sag1 > 0:


### PR DESCRIPTION
@singer-yang 

When running `2_autolens_rms.py`, if the first surface is an aperture, the code tries to compute the sag using a float `r`, which causes an AttributeError because float does not have `.sqrt()`.

This fix casts the radius to a `torch.tensor` before calling `.sag()`, ensuring compatibility with the `is_within_boundary()` check that expects tensors.

Tested on my machine with the following configuration:
- Python 3.9
- Torch version: 2.1.0
- GPU: NVIDIA RTX A5000

Fix location: `deeplens/geolens.py`, line ~2357.

Let me know if further tests or changes are needed. Thank you for this amazing project!
